### PR TITLE
Fix: Exception while trying to acquire the JMH lock (C:\Windows\/jmh.lock): Access is denied

### DIFF
--- a/src/ru/artyushov/jmhPlugin/configuration/JmhConfiguration.java
+++ b/src/ru/artyushov/jmhPlugin/configuration/JmhConfiguration.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * Date: 09/04/14
  * Time: 18:46
  */
-public class JmhConfiguration extends ModuleBasedConfiguration<JavaRunConfigurationModule>
+public class JmhConfiguration extends ModuleBasedConfiguration<JavaRunConfigurationModule, Object>
         implements CommonJavaRunConfigurationParameters, CompatibilityAwareRunProfile {
 
     public static final String ATTR_VM_PARAMETERS = "vm-parameters";

--- a/src/ru/artyushov/jmhPlugin/configuration/JmhConfigurationType.java
+++ b/src/ru/artyushov/jmhPlugin/configuration/JmhConfigurationType.java
@@ -19,7 +19,9 @@ public class JmhConfigurationType extends ConfigurationTypeBase {
         super(TYPE_ID, "Jmh", "", AllIcons.RunConfigurations.Application);
         ConfigurationFactory myFactory = new ConfigurationFactory(this) {
             public RunConfiguration createTemplateConfiguration(Project project) {
-                return new JmhConfiguration("jmh-configuration-name", project, this);
+                JmhConfiguration configuration = new JmhConfiguration("jmh-configuration-name", project, this);
+                configuration.setPassParentEnvs(true);
+                return configuration;
             }
         };
         addFactory(myFactory);


### PR DESCRIPTION
Fixes artyushov#19 by setting the `passParentEnvs` as `true` by default